### PR TITLE
Initial implementation of native kava transfer

### DIFF
--- a/core/vm/contracts_stateful.go
+++ b/core/vm/contracts_stateful.go
@@ -4,6 +4,8 @@
 package vm
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/precompile/contract"
 )
@@ -28,6 +30,7 @@ func (w *wrappedPrecompiledContract) Run(
 	input []byte,
 	suppliedGas uint64,
 	readOnly bool,
+	value *big.Int,
 ) (ret []byte, remainingGas uint64, err error) {
 	return RunPrecompiledContract(w.p, input, suppliedGas)
 }
@@ -41,6 +44,7 @@ func RunStatefulPrecompiledContract(
 	input []byte,
 	suppliedGas uint64,
 	readOnly bool,
+	value *big.Int,
 ) (ret []byte, remainingGas uint64, err error) {
-	return precompile.Run(accessibleState, caller, addr, input, suppliedGas, readOnly)
+	return precompile.Run(accessibleState, caller, addr, input, suppliedGas, readOnly, value)
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -231,7 +231,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	if isPrecompile {
-		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, evm.interpreter.readOnly)
+		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, evm.interpreter.readOnly, value)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -294,7 +294,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, evm.interpreter.readOnly)
+		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, evm.interpreter.readOnly, value)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -335,7 +335,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, evm.interpreter.readOnly)
+		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, evm.interpreter.readOnly, big0)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
@@ -387,7 +387,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 		// Explicitly pass readOnly as true for StaticCall OpCode.
 		// Precompile implementation is responsible for honoring readOnly flag.
 		// No state should be modified, return an error instead.
-		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, true)
+		ret, gas, err = RunStatefulPrecompiledContract(p, evm, caller.Address(), addr, input, gas, true, big0)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'

--- a/core/vm/precompile_test.go
+++ b/core/vm/precompile_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,7 @@ func (c *mockStatefulPrecompiledContract) Run(
 	input []byte,
 	suppliedGas uint64,
 	readOnly bool,
+	value *big.Int,
 ) (ret []byte, remainingGas uint64, err error) {
 	return []byte{}, 0, nil
 }

--- a/precompile/contract/contract.go
+++ b/precompile/contract/contract.go
@@ -5,6 +5,7 @@ package contract
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -20,6 +21,7 @@ type RunStatefulPrecompileFunc func(
 	input []byte,
 	suppliedGas uint64,
 	readOnly bool,
+	value *big.Int,
 ) (ret []byte, remainingGas uint64, err error)
 
 // StatefulPrecompileFunction defines a function implemented by a stateful precompile
@@ -76,6 +78,7 @@ func (s *statefulPrecompileWithFunctionSelectors) Run(
 	input []byte,
 	suppliedGas uint64,
 	readOnly bool,
+	value *big.Int,
 ) (ret []byte, remainingGas uint64, err error) {
 	// Otherwise, an unexpected input size will result in an error.
 	if len(input) < SelectorLen {
@@ -90,5 +93,5 @@ func (s *statefulPrecompileWithFunctionSelectors) Run(
 		return nil, suppliedGas, fmt.Errorf("invalid function selector %#x", selector)
 	}
 
-	return function.execute(accessibleState, caller, addr, functionInput, suppliedGas, readOnly)
+	return function.execute(accessibleState, caller, addr, functionInput, suppliedGas, readOnly, value)
 }

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -21,6 +21,7 @@ type StatefulPrecompiledContract interface {
 		input []byte,
 		suppliedGas uint64,
 		readOnly bool,
+		value *big.Int,
 	) (ret []byte, remainingGas uint64, err error)
 }
 

--- a/precompile/contracts/sum3/contract.go
+++ b/precompile/contracts/sum3/contract.go
@@ -58,6 +58,7 @@ func calcSum3(
 	input []byte,
 	suppliedGas uint64,
 	readOnly bool,
+	value *big.Int,
 ) (ret []byte, remainingGas uint64, err error) {
 	if remainingGas, err = contract.DeductGas(suppliedGas, calcSum3GasCost); err != nil {
 		return nil, 0, err
@@ -100,6 +101,7 @@ func getSum3(
 	input []byte,
 	suppliedGas uint64,
 	readOnly bool,
+	value *big.Int,
 ) (ret []byte, remainingGas uint64, err error) {
 	if remainingGas, err = contract.DeductGas(suppliedGas, getSum3GasCost); err != nil {
 		return nil, 0, err

--- a/precompile/contracts/sum3/contract_test.go
+++ b/precompile/contracts/sum3/contract_test.go
@@ -80,7 +80,7 @@ func TestCalcSum3GasCalculations(t *testing.T) {
 			input, err := PackCalcSum3(tc.calcSum3Input)
 			require.NoError(t, err)
 
-			ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, tc.suppliedGas, readOnly)
+			ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, tc.suppliedGas, readOnly, common.Big0)
 			if tc.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.err)
@@ -131,7 +131,7 @@ func TestGetSum3GasCalculations(t *testing.T) {
 			input, err := PackGetSum3()
 			require.NoError(t, err)
 
-			ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, tc.suppliedGas, readOnly)
+			ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, tc.suppliedGas, readOnly, common.Big0)
 			if tc.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.err)
@@ -185,7 +185,7 @@ func TestSum3Precompile(t *testing.T) {
 				input, err := PackCalcSum3(tc.calcSum3Input)
 				require.NoError(t, err)
 
-				ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, calcSum3GasCost, readOnly)
+				ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, calcSum3GasCost, readOnly, common.Big0)
 				require.NoError(t, err)
 				require.Empty(t, ret)
 				require.Equal(t, uint64(0), remainingGas)
@@ -196,7 +196,7 @@ func TestSum3Precompile(t *testing.T) {
 				input, err := PackGetSum3()
 				require.NoError(t, err)
 
-				ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, getSum3GasCost, readOnly)
+				ret, remainingGas, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, input, getSum3GasCost, readOnly, common.Big0)
 				require.NoError(t, err)
 
 				sum, err := UnpackGetSum3Output(ret)
@@ -243,7 +243,7 @@ func TestSum3PrecompileInvalidCalls(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			{
-				_, _, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, tc.input, calcSum3GasCost, readOnly)
+				_, _, err := Module.Contract.Run(accessibleState, callerAddr, contractAddr, tc.input, calcSum3GasCost, readOnly, common.Big0)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.err)
 			}


### PR DESCRIPTION
PR is necessary for implementing `precompile IBC-transfer`, low-priority for now