### PR TITLE
Add ability to dynamically enable/disable registered precompiles

### DIFF
--- a/precompile/modules/registerer.go
+++ b/precompile/modules/registerer.go
@@ -10,10 +10,28 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+type Manager interface {
+	IsEnabled(common.Address) bool
+}
+
+type defaultManager struct {
+}
+
+func newDefaultManager() Manager {
+	return defaultManager{}
+}
+
+func (_ defaultManager) IsEnabled(_ common.Address) bool {
+	return true
+}
+
 var (
 	// registeredModules is a list of Module to preserve order
 	// for deterministic iteration
 	registeredModules = make([]Module, 0)
+
+	// manager implements Manager interface
+	isEnabledManager = newDefaultManager()
 )
 
 // RegisterModule registers a stateful precompile module
@@ -32,15 +50,24 @@ func RegisterModule(stm Module) error {
 
 func GetPrecompileModuleByAddress(address common.Address) (Module, bool) {
 	for _, stm := range registeredModules {
-		if stm.Address == address {
+		if stm.Address == address && isEnabledManager.IsEnabled(stm.Address) {
 			return stm, true
 		}
 	}
 	return Module{}, false
 }
 
-func RegisteredModules() []Module {
-	return registeredModules
+func RegisteredModules() (enabledModules []Module) {
+	for _, module := range registeredModules {
+		if isEnabledManager.IsEnabled(module.Address) {
+			enabledModules = append(enabledModules, module)
+		}
+	}
+	return enabledModules
+}
+
+func SetPrecompileManager(manager Manager) {
+	isEnabledManager = manager
 }
 
 func insertSortedByAddress(data []Module, stm Module) []Module {

--- a/precompile/testutil/manager.go
+++ b/precompile/testutil/manager.go
@@ -1,0 +1,33 @@
+package testutil
+
+import "github.com/ethereum/go-ethereum/common"
+
+// Manager implements precompile IsEnabled interface
+// and allows explicit control over which addresses
+// are enabled and which are disabled
+type Manager struct {
+	enabledPrecompiles map[string]struct{}
+}
+
+// NewManager returns a new *Manager that has no precompiled enabled by default
+func NewManager() *Manager {
+	return &Manager{
+		enabledPrecompiles: make(map[string]struct{}),
+	}
+}
+
+// IsEnabled returns true if the precompile address is enabled
+func (m *Manager) IsEnabled(addr common.Address) (enabled bool) {
+	_, enabled = m.enabledPrecompiles[addr.String()]
+	return enabled
+}
+
+// Enable enables a precompile address
+func (m *Manager) Enable(addr common.Address) {
+	m.enabledPrecompiles[addr.String()] = struct{}{}
+}
+
+// Disable disables a precompile address
+func (m *Manager) Disable(addr common.Address) {
+	delete(m.enabledPrecompiles, addr.String())
+}

--- a/precompile/testutil/manager_test.go
+++ b/precompile/testutil/manager_test.go
@@ -1,0 +1,60 @@
+package testutil_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/precompile/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	addr1 = common.HexToAddress("0x9000000000000000000000000000000000000001")
+	addr2 = common.HexToAddress("0x9000000000000000000000000000000000000002")
+)
+
+func TestPrecompileManager(t *testing.T) {
+	require.False(t, addr1 == addr2, "test requires two unqiue addresses")
+
+	m := testutil.NewManager()
+
+	// defaults to no contracts enabled
+	assert.False(t, m.IsEnabled(addr1))
+	assert.False(t, m.IsEnabled(addr2))
+
+	m.Enable(addr1)
+
+	// enable 1 contract, keep other disabled
+	assert.True(t, m.IsEnabled(addr1))
+	assert.False(t, m.IsEnabled(addr2))
+
+	m.Enable(addr2)
+
+	// enable both contracts
+	assert.True(t, m.IsEnabled(addr1))
+	assert.True(t, m.IsEnabled(addr2))
+
+	m.Disable(addr1)
+
+	// disable one contract
+	assert.False(t, m.IsEnabled(addr1))
+	assert.True(t, m.IsEnabled(addr2))
+
+	m.Disable(addr2)
+
+	// disable both contracts
+	assert.False(t, m.IsEnabled(addr1))
+	assert.False(t, m.IsEnabled(addr2))
+
+	// ensure multiple calls don't panic
+	assert.NotPanics(t, func() {
+		m.Enable(addr1)
+		m.Enable(addr1)
+		m.Enable(addr1)
+
+		m.Disable(addr2)
+		m.Disable(addr2)
+		m.Disable(addr2)
+	})
+}


### PR DESCRIPTION
This adds the ability to set a precompile manager that determines which registered precompiles are enabled.

This is intended to be used from an `x/precompile` or similar module on kava chain where the keeper implements the manager interface.  This separation allows genesis to list the desired precompiles as well opens up easier integration into governance, etc.

Relates to #25

TODO:
- [ ] Integration test for vm.ActivePrecompiles (ensure enable/disable updates the returned list)
- [ ] Integration test for evm.Call, etc (ensure enable/disable can and can not be called by transactions/contracts)
- [ ] Should there be an error or validation that an enabled precompile exists?