### PR TITLE
Revert "Add custom registered precompiles to the active precompile list"

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/precompile/contract"
-	"github.com/ethereum/go-ethereum/precompile/modules"
 	"golang.org/x/crypto/ripemd160"
 )
 
@@ -152,29 +151,19 @@ func init() {
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
-func ActivePrecompiles(rules params.Rules) (precompiles []common.Address) {
+func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
 	case rules.IsCancun:
-		precompiles = PrecompiledAddressesCancun
+		return PrecompiledAddressesCancun
 	case rules.IsBerlin:
-		precompiles = PrecompiledAddressesBerlin
-
+		return PrecompiledAddressesBerlin
 	case rules.IsIstanbul:
-		precompiles = PrecompiledAddressesIstanbul
+		return PrecompiledAddressesIstanbul
 	case rules.IsByzantium:
-		precompiles = PrecompiledAddressesByzantium
+		return PrecompiledAddressesByzantium
 	default:
-		precompiles = PrecompiledAddressesHomestead
+		return PrecompiledAddressesHomestead
 	}
-
-	// TODO: Consider performance improvements here to prevent iteration & allocations on every call.
-	// NOTE: If using init to cache addresses, then some care should be taken to ensure all precompiles are
-	// registered before being cached here.
-	for _, precompile := range modules.RegisteredModules() {
-		precompiles = append(precompiles, precompile.Address)
-	}
-
-	return precompiles
 }
 
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.

--- a/core/vm/precompile_test.go
+++ b/core/vm/precompile_test.go
@@ -1,11 +1,8 @@
 package vm
 
 import (
-	"math/big"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -136,73 +133,5 @@ func TestEvmIsPrecompileMethod(t *testing.T) {
 				require.Nil(t, precompile)
 			}
 		})
-	}
-}
-
-func TestActivePrecompiles(t *testing.T) {
-	genesisTime := time.Now()
-	getBlockTime := func(height *big.Int) *uint64 {
-		if !height.IsInt64() {
-			t.Fatalf("expected height bounded to int64")
-		}
-		totalBlockSeconds := time.Duration(10*height.Int64()) * time.Second
-		blockTimeUnix := uint64(genesisTime.Add(totalBlockSeconds).Unix())
-
-		return &blockTimeUnix
-	}
-	chainConfig := params.TestChainConfig
-	chainConfig.HomesteadBlock = big.NewInt(1)
-	chainConfig.ByzantiumBlock = big.NewInt(2)
-	chainConfig.IstanbulBlock = big.NewInt(3)
-	chainConfig.BerlinBlock = big.NewInt(4)
-	chainConfig.CancunTime = getBlockTime(big.NewInt(5))
-
-	testCases := []struct {
-		name  string
-		block *big.Int
-	}{
-		{"homestead", chainConfig.HomesteadBlock},
-		{"byzantium", chainConfig.ByzantiumBlock},
-		{"istanbul", chainConfig.IstanbulBlock},
-		{"berlin", chainConfig.BerlinBlock},
-		{"cancun", new(big.Int).Add(chainConfig.BerlinBlock, big.NewInt(1))},
-	}
-
-	// custom precompile address used for test
-	contractAddress := common.HexToAddress("0x0400000000000000000000000000000000000000")
-
-	// ensure we are not being shadowed by a core preompile address
-	for _, tc := range testCases {
-		rules := chainConfig.Rules(tc.block, false, *getBlockTime(tc.block))
-
-		for _, precompileAddr := range ActivePrecompiles(rules) {
-			if precompileAddr == contractAddress {
-				t.Fatalf("expected precompile %s to not be returned in %s block", contractAddress, tc.name)
-			}
-		}
-	}
-
-	// register the precompile
-	module := modules.Module{
-		Address:  contractAddress,
-		Contract: new(mockStatefulPrecompiledContract),
-	}
-
-	// TODO: should we allow dynamic registration to update ActivePrecompiles?
-	// Or should we enforce registration only at init?
-	err := modules.RegisterModule(module)
-	require.NoError(t, err, "could not register precompile for test")
-
-	for _, tc := range testCases {
-		rules := chainConfig.Rules(tc.block, false, *getBlockTime(tc.block))
-
-		exists := false
-		for _, precompileAddr := range ActivePrecompiles(rules) {
-			if precompileAddr == contractAddress {
-				exists = true
-			}
-		}
-
-		assert.True(t, exists, "expected %s block to include active stateful precompile %s", tc.name, contractAddress)
 	}
 }


### PR DESCRIPTION
Reverts Kava-Labs/go-ethereum#21

Ethermint doesn't require this change anymore