### PR TITLE
feat: Use binary search in `GetPrecompileModuleByAddress`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum
 
-go 1.20
+go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -35,14 +35,18 @@ github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOv
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0 h1:8q4SaHjFsClSvuVne0ID/5Ka8u3fcIHyqkLjcFpNRHQ=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0 h1:vcYCAze6p19qBW7MhZybIsqD8sMV8js0NyQM8JDnVtg=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0/go.mod h1:OQeznEEkTZ9OrhHJoDD8ZDq51FHgXjqtP9z6bEwBq9U=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0 h1:Ma67P/GGprNwsslzEH6+Kb8nybI8jpDTm4Wmzu2ReK8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0/go.mod h1:c+Lifp3EDEamAkPVzMooRNOK6CZjNSdEnf1A7jsI9u4=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0 h1:gggzg0SUMs6SQbEw+3LoSsYf9YMjkupeAnHMX8O9mmY=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0/go.mod h1:+6KLcKIVgxoBDMqMO/Nvy7bZ9a0nbU3I1DtFQK3YvB4=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 h1:OBhqkivkhkMqLPymWEppkm7vgPQY2XsHoEkaMQ0AdZY=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0/go.mod h1:kgDmCTgBzIEPFElEF+FK0SdjAor06dRq2Go927dnQ6o=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
@@ -102,6 +106,7 @@ github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
@@ -121,6 +126,7 @@ github.com/cloudflare/cloudflare-go v0.79.0/go.mod h1:gkHQf9xEubaQPEuerBuoinR9P8
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v1.0.0/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
 github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f h1:otljaYPt5hWxV3MUfO5dFPFiOXg9CyG5/kCfayTqsJ4=
+github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/cockroachdb/errors v1.6.1/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
 github.com/cockroachdb/errors v1.8.1 h1:A5+txlVZfOqFBDa4mGz2bUWSp0aHElvHX2bKkdbQu+Y=
 github.com/cockroachdb/errors v1.8.1/go.mod h1:qGwQn6JmZ+oMjuLwjWzUNqblqk0xl4CVV3SQbGwK7Ac=
@@ -169,6 +175,7 @@ github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwu
 github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/dop251/goja v0.0.0-20211022113120-dc8c55024d06/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127 h1:qwcF+vdFrvPSEUDSX5RVoRccG8a5DhOdWdQ4zN62zzo=
 github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127/go.mod h1:QMWlm50DNe14hD7t24KEqZuUdC9sOTy8W6XbCU1mlw4=
@@ -329,6 +336,7 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
+github.com/hashicorp/go-hclog v1.2.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
 github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -416,6 +424,7 @@ github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvf
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
+github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -489,6 +498,7 @@ github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssy
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -497,6 +507,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=

--- a/precompile/modules/registerer.go
+++ b/precompile/modules/registerer.go
@@ -4,7 +4,9 @@
 package modules
 
 import (
+	"bytes"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -28,6 +30,23 @@ func RegisterModule(stm Module) error {
 	// sort by address to ensure deterministic iteration
 	registeredModules = insertSortedByAddress(registeredModules, stm)
 	return nil
+}
+
+// GetPrecompileModuleByAddress returns a precompile module by address and true
+// if found. Otherwise, it returns false. Uses binary search to find the module,
+// as the list is sorted by address.
+func SearchPrecompileModuleByAddress(address common.Address) (Module, bool) {
+	idx, found := slices.BinarySearchFunc(registeredModules, Module{
+		Address: address,
+	}, func(a, b Module) int {
+		return bytes.Compare(a.Address.Bytes(), b.Address.Bytes())
+	})
+
+	if !found {
+		return Module{}, false
+	}
+
+	return registeredModules[idx], true
 }
 
 func GetPrecompileModuleByAddress(address common.Address) (Module, bool) {

--- a/precompile/modules/registerer.go
+++ b/precompile/modules/registerer.go
@@ -35,7 +35,7 @@ func RegisterModule(stm Module) error {
 // GetPrecompileModuleByAddress returns a precompile module by address and true
 // if found. Otherwise, it returns false. Uses binary search to find the module,
 // as the list is sorted by address.
-func SearchPrecompileModuleByAddress(address common.Address) (Module, bool) {
+func GetPrecompileModuleByAddress(address common.Address) (Module, bool) {
 	idx, found := slices.BinarySearchFunc(registeredModules, Module{
 		Address: address,
 	}, func(a, b Module) int {
@@ -47,15 +47,6 @@ func SearchPrecompileModuleByAddress(address common.Address) (Module, bool) {
 	}
 
 	return registeredModules[idx], true
-}
-
-func GetPrecompileModuleByAddress(address common.Address) (Module, bool) {
-	for _, stm := range registeredModules {
-		if stm.Address == address {
-			return stm, true
-		}
-	}
-	return Module{}, false
 }
 
 func RegisteredModules() []Module {

--- a/precompile/modules/registerer_test.go
+++ b/precompile/modules/registerer_test.go
@@ -110,13 +110,22 @@ func BenchmarkGetPrecompileModuleByAddress(b *testing.B) {
 	}
 }
 
+func getPrecompileModuleByAddress_linear(address common.Address) (Module, bool) {
+	for _, stm := range registeredModules {
+		if stm.Address == address {
+			return stm, true
+		}
+	}
+	return Module{}, false
+}
+
 func BenchmarkGetPrecompileModuleByAddress_binarySearch(b *testing.B) {
 	setupBenchmark(b)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		address := common.BigToAddress(big.NewInt(int64(i % benchmarkModuleCount)))
-		_, found := SearchPrecompileModuleByAddress(address)
+		_, found := getPrecompileModuleByAddress_linear(address)
 		require.True(b, found)
 	}
 }

--- a/precompile/modules/registerer_test.go
+++ b/precompile/modules/registerer_test.go
@@ -79,6 +79,48 @@ func TestRegisterModule(t *testing.T) {
 	require.Equal(t, modules, registeredModules)
 }
 
+const benchmarkModuleCount = 1000
+
+func setupBenchmark(b *testing.B) {
+	ClearRegisteredModules()
+
+	// create modules
+	modules := make([]Module, benchmarkModuleCount)
+	for i := 0; i < benchmarkModuleCount; i++ {
+		modules[i] = Module{
+			Address: common.BigToAddress(big.NewInt(int64(i))),
+		}
+	}
+
+	// register modules
+	for i := 0; i < benchmarkModuleCount; i++ {
+		err := RegisterModule(modules[i])
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkGetPrecompileModuleByAddress(b *testing.B) {
+	setupBenchmark(b)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		address := common.BigToAddress(big.NewInt(int64(i % benchmarkModuleCount)))
+		_, found := GetPrecompileModuleByAddress(address)
+		require.True(b, found)
+	}
+}
+
+func BenchmarkGetPrecompileModuleByAddress_binarySearch(b *testing.B) {
+	setupBenchmark(b)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		address := common.BigToAddress(big.NewInt(int64(i % benchmarkModuleCount)))
+		_, found := SearchPrecompileModuleByAddress(address)
+		require.True(b, found)
+	}
+}
+
 func TestRegisterModuleWithDuplicateAddress(t *testing.T) {
 	ClearRegisteredModules()
 

--- a/precompile/modules/registerer_test.go
+++ b/precompile/modules/registerer_test.go
@@ -105,8 +105,9 @@ func BenchmarkGetPrecompileModuleByAddress(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		address := common.BigToAddress(big.NewInt(int64(i % benchmarkModuleCount)))
-		_, found := GetPrecompileModuleByAddress(address)
+		module, found := GetPrecompileModuleByAddress(address)
 		require.True(b, found)
+		require.Equal(b, address, module.Address)
 	}
 }
 
@@ -119,14 +120,15 @@ func getPrecompileModuleByAddress_linear(address common.Address) (Module, bool) 
 	return Module{}, false
 }
 
-func BenchmarkGetPrecompileModuleByAddress_binarySearch(b *testing.B) {
+func BenchmarkGetPrecompileModuleByAddress_linear(b *testing.B) {
 	setupBenchmark(b)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		address := common.BigToAddress(big.NewInt(int64(i % benchmarkModuleCount)))
-		_, found := getPrecompileModuleByAddress_linear(address)
+		module, found := getPrecompileModuleByAddress_linear(address)
 		require.True(b, found)
+		require.Equal(b, address, module.Address)
 	}
 }
 


### PR DESCRIPTION
- Update `GetPrecompileModuleByAddress` to use binary search
- Update go version in `go.mod` to 1.21 to support `slices` package, also used in #27

Benchmarks w/ 1000 registered modules (benchmarks included in pr):

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/precompile/modules
                                │   old.txt    │              new.txt               │
                                │    sec/op    │   sec/op     vs base               │
GetPrecompileModuleByAddress-12   1460.5n ± 1%   319.1n ± 1%  -78.15% (p=0.002 n=6)

                                │  old.txt   │            new.txt            │
                                │    B/op    │    B/op     vs base           │
GetPrecompileModuleByAddress-12   7.000 ± 0%   7.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal

                                │  old.txt   │            new.txt            │
                                │ allocs/op  │ allocs/op   vs base           │
GetPrecompileModuleByAddress-12   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal
```

resolves #29